### PR TITLE
Refactoring

### DIFF
--- a/src/sequence_label/core.py
+++ b/src/sequence_label/core.py
@@ -265,11 +265,11 @@ class LabelAlignment:
 
 
 class Move(Enum):
-    OUTSIDE = auto()
-    START = auto()
-    INSIDE = auto()
-    END = auto()
-    UNIT = auto()
+    Outside = auto()
+    Start = auto()
+    Inside = auto()
+    End = auto()
+    Unit = auto()
 
 
 class LabelSet:
@@ -303,14 +303,14 @@ class LabelSet:
         self.__end_indices = {}
         self.__unit_indices = {}
 
-        self.__states: list[tuple[Move, str | None]] = [(Move.OUTSIDE, None)]
+        self.__states: list[tuple[Move, str | None]] = [(Move.Outside, None)]
 
         for label in sorted(labels):
             self.__start_indices[label] = self.state_size
             self.__inside_indices[label] = self.state_size
             self.__end_indices[label] = self.state_size
             self.__unit_indices[label] = self.state_size
-            for move in (Move.START, Move.INSIDE, Move.END, Move.UNIT):
+            for move in (Move.Start, Move.Inside, Move.End, Move.Unit):
                 self.__states.append((move, label))
 
         self.start_states = self.__create_start_states()
@@ -512,11 +512,11 @@ class LabelSet:
                 if label is None:
                     continue
 
-                if move is Move.UNIT:
+                if move is Move.Unit:
                     tags.append(Tag.create(start=now, end=now + 1, label=label))
-                elif move is Move.END:
+                elif move is Move.End:
                     prev = now
-                    while self.__states[indices[prev]][0] is not Move.START:
+                    while self.__states[indices[prev]][0] is not Move.Start:
                         prev -= 1
                     tags.append(Tag.create(start=prev, end=now + 1, label=label))
 

--- a/src/sequence_label/core.py
+++ b/src/sequence_label/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence, Set
 from dataclasses import dataclass
 from enum import Enum, auto
 from itertools import chain
@@ -75,7 +76,7 @@ class Base(Enum):
 
 @dataclass(frozen=True)
 class SequenceLabel:
-    tags: tuple[Tag, ...]
+    tags: Sequence[Tag]
     size: int
     base: Base = Base.Source
 
@@ -100,16 +101,16 @@ class SequenceLabel:
 
     @classmethod
     def from_dict(
-        cls, tags: list[TagDict], size: int, base: Base = Base.Source
+        cls, tags: Sequence[TagDict], size: int, base: Base = Base.Source
     ) -> SequenceLabel:
-        """A named constructor for creating an instance of SequenceLabel from a list
+        """A named constructor for creating an instance of SequenceLabel from a sequence
         of dictionaries, where each dictionary has three keys start, end, and label.
         A start represents a position in the text where a tag starts. A end represents
         a position in the text where a tag ends. A label represents what you want to
         assign to a span of the text defined by a start and a end.
 
         Args:
-            tags: A list of an instance of TagDict.
+            tags: A sequence of an instance of TagDict.
             size: A integer representing a length of a text.
             base: A member of Base. Defaults to Base.SOURCE.
 
@@ -117,11 +118,9 @@ class SequenceLabel:
             An instance of SequenceLabel.
         """
         return cls(
-            tags=tuple(
-                sorted(
-                    Tag.create(start=tag["start"], end=tag["end"], label=tag["label"])
-                    for tag in tags
-                )
+            tags=sorted(
+                Tag.create(start=tag["start"], end=tag["end"], label=tag["label"])
+                for tag in tags
             ),
             size=size,
             base=base,
@@ -133,15 +132,15 @@ class LabelAlignment:
     to target sequences after tokenization, and vice versa.
 
     Args:
-        source_spans: A tuple where each item represents an interval in the source
-            sequence. The index of the item in the tuple corresponds to a specific
+        source_spans: A sequence where each item represents an interval in the source
+            sequence. The index of the item in the sequence corresponds to a specific
             position in the target sequence. In other words, an interval in
             the source sequence and a position in the target sequence have a one-to-one
             correspondence.
             If a span is None, it indicates that the respective position in the target
             sequence doesn't have a matching interval in the source sequence.
-        target_spans: A tuple where each item represents an interval in the target
-            sequence. The index of the item in the tuple corresponds to a specific
+        target_spans: A sequence where each item represents an interval in the target
+            sequence. The index of the item in the sequence corresponds to a specific
             position in the source sequence. In other words, an interval in
             the target sequence and a position in the source sequence have a one-to-one
             correspondence.
@@ -155,8 +154,8 @@ class LabelAlignment:
 
     def __init__(
         self,
-        source_spans: tuple[Span | None, ...],
-        target_spans: tuple[Span | None, ...],
+        source_spans: Sequence[Span | None],
+        target_spans: Sequence[Span | None],
     ):
         target_size = len(source_spans)
         if not all(
@@ -193,11 +192,11 @@ class LabelAlignment:
     def target_size(self) -> int:
         return len(self.__source_spans)
 
-    def get_span_lengths(self, base: Base) -> tuple[int, ...]:
+    def get_span_lengths(self, base: Base) -> Sequence[int]:
         if base == Base.Source:
-            return tuple(span.length if span else 0 for span in self.__source_spans)
+            return [span.length if span else 0 for span in self.__source_spans]
         elif base == Base.Target:
-            return tuple(span.length if span else 0 for span in self.__target_spans)
+            return [span.length if span else 0 for span in self.__target_spans]
         else:
             raise ValueError(f"{base} is not supported.")
 
@@ -261,7 +260,7 @@ class LabelAlignment:
                 )
             )
 
-        return SequenceLabel(tags=tuple(tags), size=target_size, base=tgt)
+        return SequenceLabel(tags=tags, size=target_size, base=tgt)
 
 
 class Move(Enum):
@@ -285,16 +284,16 @@ class LabelSet:
         state_size: An integer representing total number of labels with states.
         outside_index: An integer corresponding to an outside state.
         padding_index: An integer representing a padding value.
-        start_states: A list of boolean values representing the start states.
+        start_states: A sequence of boolean values representing the start states.
             True indicates an allowed state, while False indicates an otherwise state.
-        end_states: A list of boolean values representing the end states.
+        end_states: A sequence of boolean values representing the end states.
             True indicates an allowed state, while False indicates an otherwise state.
-        transitions: A list of lists of boolean values representing the transitions.
+        transitions: A sequence of sequence of boolean values representing the transitions.
             True indicates an allowed transition, while False indicates an otherwise
             transition.
     """
 
-    def __init__(self, labels: set[str], padding_index: int = -1):
+    def __init__(self, labels: Set[str], padding_index: int = -1):
         self.__outside_index = 0
         self.__padding_index = padding_index
 
@@ -303,7 +302,7 @@ class LabelSet:
         self.__end_indices = {}
         self.__unit_indices = {}
 
-        self.__states: list[tuple[Move, str | None]] = [(Move.Outside, None)]
+        self.__states: Sequence[tuple[Move, str | None]] = [(Move.Outside, None)]
 
         for label in sorted(labels):
             self.__start_indices[label] = self.state_size
@@ -350,7 +349,7 @@ class LabelSet:
             )
         )
 
-    def get_tag_indices(self, tag: Tag) -> list[int]:
+    def get_tag_indices(self, tag: Tag) -> Sequence[int]:
         if tag.label not in self:
             raise ValueError(f"Invalid label is given: {tag.label}")
 
@@ -364,7 +363,7 @@ class LabelSet:
                 + [self.__end_indices[tag.label]]
             )
 
-    def get_tag_bitmap(self, tag: Tag) -> list[list[bool]]:
+    def get_tag_bitmap(self, tag: Tag) -> Sequence[Sequence[bool]]:
         indices = self.get_tag_indices(tag=tag)
 
         bitmap = [[False] * self.state_size for _ in range(tag.length)]
@@ -375,17 +374,17 @@ class LabelSet:
 
     def encode_to_tag_indices(
         self,
-        labels: tuple[SequenceLabel, ...],
-        alignments: tuple[LabelAlignment, ...] | None = None,
-    ) -> list[list[int]]:
-        """Creates a list of active tag indices from given labels.
+        labels: Sequence[SequenceLabel],
+        alignments: Sequence[LabelAlignment] | None = None,
+    ) -> Sequence[Sequence[int]]:
+        """Creates a sequence of active tag indices from given labels.
 
         Args:
-            labels: A tuple of instances of SequenceLabel.
-            alignments: A tuple of instances of LabelAlignment. Defaults to None.
+            labels: A sequence of instances of SequenceLabel.
+            alignments: A sequence of instances of LabelAlignment. Defaults to None.
 
         Returns:
-            A list of integers, where each integer represents an active tag.
+            A sequence of integers, where each integer represents an active tag.
 
         """
         if alignments is not None and len(labels) != len(alignments):
@@ -395,10 +394,10 @@ class LabelSet:
             )
 
         if alignments is not None:
-            labels = tuple(
+            labels = [
                 alignment.align_with_target(label=label)
                 for label, alignment in zip(labels, alignments)
-            )
+            ]
 
         max_size = max(label.size for label in labels)
 
@@ -419,18 +418,18 @@ class LabelSet:
 
     def encode_to_tag_bitmap(
         self,
-        labels: tuple[SequenceLabel, ...],
-        alignments: tuple[LabelAlignment, ...] | None = None,
-    ) -> list[list[list[bool]]]:
+        labels: Sequence[SequenceLabel],
+        alignments: Sequence[LabelAlignment] | None = None,
+    ) -> Sequence[Sequence[Sequence[bool]]]:
         """Creates a tag bitmap indicating the presence of active tags from
         given labels.
 
         Args:
-            labels: A tuple of instances of SequenceLabel.
-            alignments: A tuple of instances of LabelAlignment. Defaults to None.
+            labels: A sequence of instances of SequenceLabel.
+            alignments: A sequence of instances of LabelAlignment. Defaults to None.
 
         Returns:
-            A list of lists of booleans, where each boolean represents an active tag.
+            A sequence of sequences of booleans, where each boolean represents an active tag.
 
         """
         if alignments is not None and len(labels) != len(alignments):
@@ -440,10 +439,10 @@ class LabelSet:
             )
 
         if alignments is not None:
-            labels = tuple(
+            labels = [
                 alignment.align_with_target(label=label)
                 for label, alignment in zip(labels, alignments)
-            )
+            ]
 
         max_size = max(label.size for label in labels)
 
@@ -466,17 +465,17 @@ class LabelSet:
 
     def decode(
         self,
-        tag_indices: list[list[int]],
-        alignments: tuple[LabelAlignment, ...] | None = None,
-    ) -> tuple[SequenceLabel, ...]:
+        tag_indices: Sequence[Sequence[int]],
+        alignments: Sequence[LabelAlignment] | None = None,
+    ) -> Sequence[SequenceLabel]:
         """Reconstructs labels from given tag indices.
 
         Args:
-            tag_indices: A list of integer, where each item represents a tag index.
-            alignments: A tuple of instances of LabelAlignment. Defaults to None.
+            tag_indices: A sequence of integer, where each item represents a tag index.
+            alignments: A sequence of instances of LabelAlignment. Defaults to None.
 
         Returns:
-            A tuple of instances of SequenceLabel.
+            A sequence of instances of SequenceLabel.
         """
         if alignments is not None and len(tag_indices) != len(alignments):
             raise ValueError(
@@ -520,21 +519,21 @@ class LabelSet:
                         prev -= 1
                     tags.append(Tag.create(start=prev, end=now + 1, label=label))
 
-            labels.append(SequenceLabel(tags=tuple(tags), size=len(indices), base=base))
+            labels.append(SequenceLabel(tags=tags, size=len(indices), base=base))
 
         if alignments is not None:
-            return tuple(
+            return [
                 alignment.align_with_source(label)
                 for label, alignment in zip(labels, alignments)
-            )
+            ]
         else:
-            return tuple(labels)
+            return labels
 
-    def __create_start_states(self) -> tuple[bool, ...]:
-        """Creates a list of booleans representing an allowed start states.
+    def __create_start_states(self) -> Sequence[bool]:
+        """Creates a sequence of booleans representing an allowed start states.
 
         Returns:
-            A list of booleans representing allowed start states,
+            A sequence of booleans representing allowed start states,
             where each item is: True for its index allowed and False otherwise.
 
         """
@@ -545,13 +544,13 @@ class LabelSet:
         for index in chain(self.__start_indices.values(), self.__unit_indices.values()):
             states[index] = True
 
-        return tuple(states)
+        return states
 
-    def __create_end_states(self) -> tuple[bool, ...]:
-        """Creates a list of booleans representing an allowed end states.
+    def __create_end_states(self) -> Sequence[bool]:
+        """Creates a sequence of booleans representing an allowed end states.
 
         Returns:
-            A list of booleans representing allowed end states,
+            A sequence of booleans representing allowed end states,
             where each item is: True for its index allowed and False otherwise.
 
         """
@@ -562,14 +561,14 @@ class LabelSet:
         for index in chain(self.__end_indices.values(), self.__unit_indices.values()):
             states[index] = True
 
-        return tuple(states)
+        return states
 
-    def __create_transitions(self) -> tuple[tuple[bool, ...], ...]:
-        """Creates a list of lists of booleans representing
+    def __create_transitions(self) -> Sequence[Sequence[bool]]:
+        """Creates a sequence of sequences of booleans representing
         allowed transitions between tags.
 
         Returns:
-            A list of lists of booleans representing allowed transitions between tags,
+            A sequence of sequences of booleans representing allowed transitions between tags,
             where each item is: True for an allowed transition and False otherwise.
 
         """
@@ -605,4 +604,4 @@ class LabelSet:
             ):
                 transitions[unit_index][ok_index] = True
 
-        return tuple(tuple(row) for row in transitions)
+        return transitions

--- a/src/sequence_label/core.py
+++ b/src/sequence_label/core.py
@@ -69,15 +69,15 @@ class TagDict(TypedDict):
 
 
 class Base(Enum):
-    SOURCE = auto()
-    TARGET = auto()
+    Source = auto()
+    Target = auto()
 
 
 @dataclass(frozen=True)
 class SequenceLabel:
     tags: tuple[Tag, ...]
     size: int
-    base: Base = Base.SOURCE
+    base: Base = Base.Source
 
     def __post_init__(self) -> None:
         if any(self.tags[i] > self.tags[i + 1] for i in range(len(self.tags) - 1)):
@@ -100,7 +100,7 @@ class SequenceLabel:
 
     @classmethod
     def from_dict(
-        cls, tags: list[TagDict], size: int, base: Base = Base.SOURCE
+        cls, tags: list[TagDict], size: int, base: Base = Base.Source
     ) -> SequenceLabel:
         """A named constructor for creating an instance of SequenceLabel from a list
         of dictionaries, where each dictionary has three keys start, end, and label.
@@ -194,9 +194,9 @@ class LabelAlignment:
         return len(self.__source_spans)
 
     def get_span_lengths(self, base: Base) -> tuple[int, ...]:
-        if base == Base.SOURCE:
+        if base == Base.Source:
             return tuple(span.length if span else 0 for span in self.__source_spans)
-        elif base == Base.TARGET:
+        elif base == Base.Target:
             return tuple(span.length if span else 0 for span in self.__target_spans)
         else:
             raise ValueError(f"{base} is not supported.")
@@ -210,7 +210,7 @@ class LabelAlignment:
         Returns:
             A character-based sequence label.
         """
-        return self.__align(label=label, src=Base.TARGET, tgt=Base.SOURCE)
+        return self.__align(label=label, src=Base.Target, tgt=Base.Source)
 
     def align_with_target(self, label: SequenceLabel) -> SequenceLabel:
         """Converts character-based tags to token-based tags. Note that this operation
@@ -223,10 +223,10 @@ class LabelAlignment:
         Returns:
             A token-based sequence label.
         """
-        return self.__align(label=label, src=Base.SOURCE, tgt=Base.TARGET)
+        return self.__align(label=label, src=Base.Source, tgt=Base.Target)
 
     def __align(self, label: SequenceLabel, src: Base, tgt: Base) -> SequenceLabel:
-        if tgt == Base.TARGET:
+        if tgt == Base.Target:
             source_size = self.source_size
             target_size = self.target_size
             spans = self.__target_spans
@@ -503,7 +503,7 @@ class LabelSet:
                 if not self.transitions[i][j]:
                     raise ValueError("Invalid indices.")
 
-        base = Base.SOURCE if alignments is None else Base.TARGET
+        base = Base.Source if alignments is None else Base.Target
         labels = []
         for indices in tag_indices:
             tags = []

--- a/src/sequence_label/transformers/core.py
+++ b/src/sequence_label/transformers/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from collections.abc import Sequence
 
 from sequence_label import LabelAlignment
 from sequence_label.core import Span
@@ -14,23 +15,23 @@ __all__ = ["create_alignments"]
 
 def create_alignments(
     batch_encoding: BatchEncoding,
-    lengths: list[int],
+    lengths: Sequence[int],
     is_split_into_words: bool = False,
     padding_token: str | None = None,
-) -> tuple[LabelAlignment, ...]:
+) -> Sequence[LabelAlignment]:
     """Creates instances of LabelAlignment from an instance of BatchEncoding that
     is a result of the Huggingface tokenizer.
 
     Args:
         batch_encoding: An instance of BatchEncoding.
-        lengths: A list of integers where each item represents a length of text.
+        lengths: A sequence of integers where each item represents a length of text.
         is_split_into_words: A boolean representing whether is_split_into_words was
             enabled during tokenization. Defaults to False.
         padding_token: A string representing a special token used to make lists of
             tokens the same size for batching purpose. Defaults to None.
 
     Returns:
-        a tuple of instances of LabelAlignment.
+        a sequence of instances of LabelAlignment.
     """
     if not batch_encoding.is_fast:
         raise ValueError("Please use a subclass of PreTrainedTokenizerFast.")
@@ -59,8 +60,8 @@ def create_alignments(
 
             alignments.append(
                 LabelAlignment(
-                    source_spans=tuple(src_char_spans),
-                    target_spans=tuple(tgt_token_spans),
+                    source_spans=src_char_spans,
+                    target_spans=tgt_token_spans,
                 )
             )
     else:
@@ -82,8 +83,8 @@ def create_alignments(
 
             alignments.append(
                 LabelAlignment(
-                    source_spans=tuple(src_token_spans),
-                    target_spans=tuple(tgt_word_spans),
+                    source_spans=src_token_spans,
+                    target_spans=tgt_word_spans,
                 )
             )
-    return tuple(alignments)
+    return alignments

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import cast
+from collections.abc import Sequence
 
 import pytest
 from hypothesis import given
@@ -11,7 +12,7 @@ from sequence_label.core import Base, Span, TagDict
 
 
 @st.composite
-def source_labels(draw: st.DrawFn) -> tuple[SequenceLabel, ...]:
+def source_labels(draw: st.DrawFn) -> Sequence[SequenceLabel]:
     size = 100
     num_labels = 8
     max_num_tags = 20
@@ -32,12 +33,12 @@ def source_labels(draw: st.DrawFn) -> tuple[SequenceLabel, ...]:
             last = end + 1
         labels.append(SequenceLabel.from_dict(tags=tags, size=size))
 
-    return tuple(labels)
+    return labels
 
 
 @given(labels=source_labels())
 def test_labels_unchanged_after_encoding_and_decoding(
-    labels: tuple[SequenceLabel, ...]
+    labels: Sequence[SequenceLabel],
 ) -> None:
     label_set = LabelSet({"ORG", "LOC", "PER", "MISC"})
     assert labels == label_set.decode(label_set.encode_to_tag_indices(labels))
@@ -197,7 +198,7 @@ def test_membership_check_is_valid(
 
 
 def test_start_states_are_valid(label_set: LabelSet) -> None:
-    expected = (
+    expected = [
         True,  # O
         True,  # B-ORG
         False,  # I-ORG
@@ -207,13 +208,13 @@ def test_start_states_are_valid(label_set: LabelSet) -> None:
         False,  # I-PER
         False,  # L-PER
         True,  # U-PER
-    )
+    ]
 
     assert label_set.start_states == expected
 
 
 def test_end_states_are_valid(label_set: LabelSet) -> None:
-    expected = (
+    expected = [
         True,  # O
         False,  # B-ORG
         False,  # I-ORG
@@ -223,14 +224,14 @@ def test_end_states_are_valid(label_set: LabelSet) -> None:
         False,  # I-PER
         True,  # L-PER
         True,  # U-PER
-    )
+    ]
 
     assert label_set.end_states == expected
 
 
 def test_transitions_are_valid(label_set: LabelSet) -> None:
-    expected = (
-        (
+    expected = [
+        [
             True,  # O
             True,  # B-ORG
             False,  # I-ORG
@@ -240,8 +241,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             True,  # U-PER
-        ),  # O
-        (
+        ],  # O
+        [
             False,  # O
             False,  # B-ORG
             True,  # I-ORG
@@ -251,8 +252,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             False,  # U-PER
-        ),  # B-ORG
-        (
+        ],  # B-ORG
+        [
             False,  # O
             False,  # B-ORG
             True,  # I-ORG
@@ -262,8 +263,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             False,  # U-PER
-        ),  # I-ORG
-        (
+        ],  # I-ORG
+        [
             True,  # O
             True,  # B-ORG
             False,  # I-ORG
@@ -273,8 +274,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             True,  # U-PER
-        ),  # L-ORG
-        (
+        ],  # L-ORG
+        [
             True,  # O
             True,  # B-ORG
             False,  # I-ORG
@@ -284,8 +285,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             True,  # U-PER
-        ),  # U-ORG
-        (
+        ],  # U-ORG
+        [
             False,  # O
             False,  # B-ORG
             False,  # I-ORG
@@ -295,8 +296,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             True,  # I-PER
             True,  # L-PER
             False,  # U-PER
-        ),  # B-PER
-        (
+        ],  # B-PER
+        [
             False,  # O
             False,  # B-ORG
             False,  # I-ORG
@@ -306,8 +307,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             True,  # I-PER
             True,  # L-PER
             False,  # U-PER
-        ),  # I-PER
-        (
+        ],  # I-PER
+        [
             True,  # O
             True,  # B-ORG
             False,  # I-ORG
@@ -317,8 +318,8 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             True,  # U-PER
-        ),  # L-PER
-        (
+        ],  # L-PER
+        [
             True,  # O
             True,  # B-ORG
             False,  # I-ORG
@@ -328,7 +329,7 @@ def test_transitions_are_valid(label_set: LabelSet) -> None:
             False,  # I-PER
             False,  # L-PER
             True,  # U-PER
-        ),  # U-PER
-    )
+        ],  # U-PER
+    ]
 
     assert label_set.transitions == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -59,7 +59,7 @@ def target_label(draw: st.DrawFn) -> SequenceLabel:
         tags.append(cast(TagDict, {"start": start, "end": end, "label": label}))
         last = end + 1
 
-    return SequenceLabel.from_dict(tags=tags, size=size + 1, base=Base.TARGET)
+    return SequenceLabel.from_dict(tags=tags, size=size + 1, base=Base.Target)
 
 
 @given(label=target_label())
@@ -167,7 +167,7 @@ def test_tags_define_in_truncated_part_ignored() -> None:
         size=30,
     )
     expected = SequenceLabel.from_dict(
-        tags=[{"start": 1, "end": 3, "label": "LOC"}], size=4, base=Base.TARGET
+        tags=[{"start": 1, "end": 3, "label": "LOC"}], size=4, base=Base.Target
     )
 
     assert truncated_alignment.align_with_target(label=label) == expected

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import pytest
@@ -38,7 +39,7 @@ def label_set() -> LabelSet:
             "Tokyo is the capital of Japan.",
             [[0, 1, 3, 0, 0, 0, 0, 4, 0, 0]],
             "tokenizer",
-            (
+            [
                 SequenceLabel.from_dict(
                     tags=[
                         {"start": 0, "end": 5, "label": "LOC"},
@@ -46,13 +47,13 @@ def label_set() -> LabelSet:
                     ],
                     size=30,
                 ),
-            ),
+            ],
         ),
         (
             "Tokyo is the capital of Japan. ",
             [[0, 1, 3, 0, 0, 0, 0, 4, 0, 0, 0]],
             "tokenizer",
-            (
+            [
                 SequenceLabel.from_dict(
                     tags=[
                         {"start": 0, "end": 5, "label": "LOC"},
@@ -60,13 +61,13 @@ def label_set() -> LabelSet:
                     ],
                     size=31,
                 ),
-            ),
+            ],
         ),
         (
             "John Doe",
             [[0, 16, 16, 0]],
             "tokenizer",
-            (
+            [
                 SequenceLabel.from_dict(
                     tags=[
                         {"start": 0, "end": 4, "label": "PER"},
@@ -74,27 +75,27 @@ def label_set() -> LabelSet:
                     ],
                     size=8,
                 ),
-            ),
+            ],
         ),
         (
             "John Doe",
             [[0, 13, 15, 0]],
             "tokenizer",
-            (
+            [
                 SequenceLabel.from_dict(
                     tags=[{"start": 0, "end": 8, "label": "PER"}], size=8
                 ),
-            ),
+            ],
         ),
         (
             ["Named-entity", "recognition", "is", "very", "interesting", "."],
             [[0, 5, 6, 6, 7, 0, 0, 0, 0, 0]],
             "tokenizer_word",
-            (
+            [
                 SequenceLabel.from_dict(
                     tags=[{"start": 0, "end": 2, "label": "MISC"}], size=6
                 ),
-            ),
+            ],
         ),
     ],
 )
@@ -104,7 +105,7 @@ def test_decoded_labels_are_valid(
     text: str | list[str],
     tag_indices: list[list[int]],
     tokenizer_type: str,
-    expected: tuple[SequenceLabel, ...],
+    expected: Sequence[SequenceLabel],
 ) -> None:
     tokenizer = request.getfixturevalue(tokenizer_type)
     batch_encoding = tokenizer(text)
@@ -758,7 +759,7 @@ def test_tag_bitmap_is_valid(
     label_set: LabelSet,
     tokenizer: PreTrainedTokenizerFast,
     text: str,
-    labels: tuple[SequenceLabel, ...],
+    labels: Sequence[SequenceLabel],
     expected: list[list[list[bool]]],
 ) -> None:
     batch_encoding = tokenizer([text], truncation=True)


### PR DESCRIPTION
- Change the case of the `Base` and `Move` variants
- Use `collections.abc.Sequence` instead of `list` and `tuple`